### PR TITLE
emit to specific outbound q

### DIFF
--- a/core/src/batch/mod.rs
+++ b/core/src/batch/mod.rs
@@ -30,9 +30,9 @@ pub enum Disposition<T: Packet> {
     /// Indicating the packet should be processed.
     Act(T),
 
-    /// Indicating to skip any further processing and emit the packet as
-    /// is. The packet short-circuits the rest of the pipeline.
-    Emit(Mbuf),
+    /// Indicating the packet has already been sent, possibly through a
+    /// different `PacketTx`.
+    Emit,
 
     /// Indicating the packet is intentionally dropped from the output.
     Drop(Mbuf),
@@ -51,7 +51,7 @@ impl<T: Packet> Disposition<T> {
     {
         match self {
             Disposition::Act(packet) => f(packet),
-            Disposition::Emit(mbuf) => Disposition::Emit(mbuf),
+            Disposition::Emit => Disposition::Emit,
             Disposition::Drop(mbuf) => Disposition::Drop(mbuf),
             Disposition::Abort(mbuf, err) => Disposition::Abort(mbuf, err),
         }
@@ -68,7 +68,7 @@ impl<T: Packet> Disposition<T> {
     /// Returns whether the disposition is `Emit`.
     pub fn is_emit(&self) -> bool {
         match self {
-            Disposition::Emit(_) => true,
+            Disposition::Emit => true,
             _ => false,
         }
     }
@@ -116,16 +116,18 @@ pub trait Batch {
     /// the next cycle, call `replenish` first.
     fn next(&mut self) -> Option<Disposition<Self::Item>>;
 
-    /// Creates a batch that marks all unmarked packets for transmission.
+    /// Creates a batch that transmits all packets through the specified
+    /// `PacketTx`.
     ///
-    /// Use when processing is complete and no further modifications are
-    /// necessary. Any further combinators will have no effect on packets
-    /// that have been through the emit batch.
-    fn emit(self) -> Emit<Self>
+    /// Use when packets need to be delivered to a destination different
+    /// from the pipeline's main outbound queue. The send is immediate and
+    /// is not in batch. Packets sent with `emit` will be out of order
+    /// relative to other packets in the batch.
+    fn emit<Tx: PacketTx>(self, tx: Tx) -> Emit<Self, Tx>
     where
         Self: Sized,
     {
-        Emit::new(self)
+        Emit::new(self, tx)
     }
 
     /// Creates a batch that uses a predicate to determine if a packet
@@ -247,25 +249,34 @@ mod tests {
     use crate::packets::ip::ProtocolNumbers;
     use crate::packets::Ethernet;
     use crate::testils::byte_arrays::{ICMPV4_PACKET, TCP_PACKET, UDP_PACKET};
+    use std::sync::mpsc;
 
     fn new_batch(data: &[&[u8]]) -> impl Batch<Item = Mbuf> {
-        let q = data
+        let packets = data
             .iter()
             .map(|bytes| Mbuf::from_bytes(bytes).unwrap())
             .collect::<Vec<_>>();
-        let mut batch = Poll::new(q);
+
+        let (mut tx, rx) = mpsc::channel();
+        tx.transmit(packets);
+        let mut batch = Poll::new(rx);
         batch.replenish();
         batch
     }
 
     #[nb2::test]
     fn emit_batch() {
+        let (tx, mut rx) = mpsc::channel();
+
         let mut batch = new_batch(&[&UDP_PACKET])
             .map(|p| p.parse::<Ethernet>())
-            .emit()
+            .emit(tx)
             .for_each(|_| panic!("emit broken!"));
 
         assert!(batch.next().unwrap().is_emit());
+
+        // sent to the tx
+        assert_eq!(1, rx.receive().len());
     }
 
     #[nb2::test]

--- a/core/src/batch/rxtx.rs
+++ b/core/src/batch/rxtx.rs
@@ -32,7 +32,6 @@ impl PacketTx for Sender<Mbuf> {
     fn transmit(&mut self, packets: Vec<Mbuf>) {
         packets.into_iter().for_each(|packet| {
             let _ = self.send(packet);
-            ()
         });
     }
 }

--- a/core/src/batch/rxtx.rs
+++ b/core/src/batch/rxtx.rs
@@ -2,11 +2,13 @@
 //!
 //! Implemented for `PortQueue`.
 //!
-//! Implemented for `Vec` so it can be used as the batch source mostly
-//! in tests.
+//! Implemented for the MPSC channel so it can be used as a batch source
+//! mostly in tests.
 
 use super::{PacketRx, PacketTx};
 use crate::{Mbuf, PortQueue};
+use std::iter;
+use std::sync::mpsc::{Receiver, Sender};
 
 impl PacketRx for PortQueue {
     fn receive(&mut self) -> Vec<Mbuf> {
@@ -20,15 +22,18 @@ impl PacketTx for PortQueue {
     }
 }
 
-impl PacketRx for Vec<Mbuf> {
+impl PacketRx for Receiver<Mbuf> {
     fn receive(&mut self) -> Vec<Mbuf> {
-        self.drain(..).collect()
+        iter::from_fn(|| self.try_recv().ok()).collect::<Vec<_>>()
     }
 }
 
-impl PacketTx for Vec<Mbuf> {
+impl PacketTx for Sender<Mbuf> {
     fn transmit(&mut self, packets: Vec<Mbuf>) {
-        self.extend_from_slice(&packets)
+        packets.into_iter().for_each(|packet| {
+            let _ = self.send(packet);
+            ()
+        });
     }
 }
 

--- a/core/src/batch/send.rs
+++ b/core/src/batch/send.rs
@@ -29,9 +29,9 @@ impl<B: Batch, Tx: PacketTx> Send<B, Tx> {
         while let Some(disp) = self.batch.next() {
             match disp {
                 Disposition::Act(packet) => transmit_q.push(packet.reset()),
-                Disposition::Emit(mbuf) => transmit_q.push(mbuf),
                 Disposition::Drop(mbuf) => drop_q.push(mbuf),
                 Disposition::Abort(mbuf, _) => drop_q.push(mbuf),
+                Disposition::Emit => (),
             }
         }
 


### PR DESCRIPTION
* changed emit to transmit the packet to a different q right away.
* also changed the tests to use a mpsc instead of plain vec for rx and tx. vec is not flexible enough for assertions because it can only be owned by the pipeline.