### PR TITLE
avoid cloning packets in batch combinators

### DIFF
--- a/core/src/batch/filter.rs
+++ b/core/src/batch/filter.rs
@@ -36,15 +36,14 @@ where
 
     #[inline]
     fn next(&mut self) -> Option<Disposition<Self::Item>> {
-        self.batch.next().map(|disp| match disp {
-            Disposition::Act(packet) => {
-                if (self.predicate)(&packet) {
-                    Disposition::Act(packet)
+        self.batch.next().map(|disp| {
+            disp.map(|pkt| {
+                if (self.predicate)(&pkt) {
+                    Disposition::Act(pkt)
                 } else {
-                    Disposition::Drop(packet.reset())
+                    Disposition::Drop(pkt.reset())
                 }
-            }
-            _ => disp,
+            })
         })
     }
 }

--- a/core/src/batch/filter_map.rs
+++ b/core/src/batch/filter_map.rs
@@ -1,15 +1,24 @@
 use super::{Batch, Disposition};
 use crate::packets::Packet;
-use crate::Result;
+use crate::{Mbuf, Result};
+
+/// The outcome of the filter map.
+pub enum Outcome<T> {
+    /// Keeps the packet as mapped result.
+    Keep(T),
+
+    /// Drops the packet.
+    Drop(Mbuf),
+}
 
 /// A batch that both filters and maps the packets of the underlying batch.
 ///
-/// If the closure returns `None`, the packet is marked as dropped. On
+/// If the closure returns `Drop`, the packet is marked as dropped. On
 /// error, the packet is marked as aborted. In both scenarios, it will
 /// short-circuit the remainder of the pipeline.
 pub struct FilterMap<B: Batch, T: Packet, F>
 where
-    F: FnMut(B::Item) -> Result<Option<T>>,
+    F: FnMut(B::Item) -> Result<Outcome<T>>,
 {
     batch: B,
     f: F,
@@ -17,7 +26,7 @@ where
 
 impl<B: Batch, T: Packet, F> FilterMap<B, T, F>
 where
-    F: FnMut(B::Item) -> Result<Option<T>>,
+    F: FnMut(B::Item) -> Result<Outcome<T>>,
 {
     #[inline]
     pub fn new(batch: B, f: F) -> Self {
@@ -27,7 +36,7 @@ where
 
 impl<B: Batch, T: Packet, F> Batch for FilterMap<B, T, F>
 where
-    F: FnMut(B::Item) -> Result<Option<T>>,
+    F: FnMut(B::Item) -> Result<Outcome<T>>,
 {
     type Item = T;
 
@@ -39,17 +48,10 @@ where
     #[inline]
     fn next(&mut self) -> Option<Disposition<Self::Item>> {
         self.batch.next().map(|disp| {
-            disp.map(|orig| {
-                let mbuf = orig.mbuf().clone();
-
-                match (self.f)(orig) {
-                    Ok(Some(new)) => {
-                        std::mem::forget(mbuf);
-                        Disposition::Act(new)
-                    }
-                    Ok(None) => Disposition::Drop(mbuf),
-                    Err(e) => Disposition::Abort(mbuf, e),
-                }
+            disp.map(|orig| match (self.f)(orig) {
+                Ok(Outcome::Keep(new)) => Disposition::Act(new),
+                Ok(Outcome::Drop(mbuf)) => Disposition::Drop(mbuf),
+                Err(e) => Disposition::Abort(e),
             })
         })
     }

--- a/core/src/batch/for_each.rs
+++ b/core/src/batch/for_each.rs
@@ -1,5 +1,4 @@
 use super::{Batch, Disposition};
-use crate::packets::Packet;
 use crate::Result;
 
 /// A batch that calls a closure on packets in the underlying batch.
@@ -37,7 +36,7 @@ where
         self.batch.next().map(|disp| {
             disp.map(|pkt| match (self.f)(&pkt) {
                 Ok(_) => Disposition::Act(pkt),
-                Err(e) => Disposition::Abort(pkt.reset(), e),
+                Err(e) => Disposition::Abort(e),
             })
         })
     }

--- a/core/src/batch/mod.rs
+++ b/core/src/batch/mod.rs
@@ -146,7 +146,7 @@ pub trait Batch {
     #[inline]
     fn filter_map<T: Packet, F>(self, f: F) -> FilterMap<Self, T, F>
     where
-        F: FnMut(Self::Item) -> Result<Outcome<T>>,
+        F: FnMut(Self::Item) -> Result<Either<T>>,
         Self: Sized,
     {
         FilterMap::new(self, f)
@@ -294,9 +294,9 @@ mod tests {
         let mut batch = new_batch(&[&UDP_PACKET, &ICMPV4_PACKET]).filter_map(|p| {
             let v4 = p.parse::<Ethernet>()?.parse::<Ipv4>()?;
             if v4.protocol() == ProtocolNumbers::Udp {
-                Ok(Outcome::Keep(v4))
+                Ok(Either::Keep(v4))
             } else {
-                Ok(Outcome::Drop(v4.reset()))
+                Ok(Either::Drop(v4.reset()))
             }
         });
 

--- a/core/src/batch/mod.rs
+++ b/core/src/batch/mod.rs
@@ -38,7 +38,8 @@ pub enum Disposition<T: Packet> {
     Drop(Mbuf),
 
     /// Indicating an error has occurred during processing. The packet will
-    /// be dropped from the output.
+    /// be dropped from the output. Aborted packets are not bulk freed.
+    /// The packet is returned to mempool when it goes out of scope.
     Abort(Error),
 }
 

--- a/core/src/batch/send.rs
+++ b/core/src/batch/send.rs
@@ -30,8 +30,8 @@ impl<B: Batch, Tx: PacketTx> Send<B, Tx> {
             match disp {
                 Disposition::Act(packet) => transmit_q.push(packet.reset()),
                 Disposition::Drop(mbuf) => drop_q.push(mbuf),
-                Disposition::Abort(mbuf, _) => drop_q.push(mbuf),
-                Disposition::Emit => (),
+                // nothing to do for abort and emit.
+                _ => (),
             }
         }
 


### PR DESCRIPTION
We are cloning the mbufs before transferring the ownership of the packet to `map` or `filter_map` function. So if the function throws an error, we will queue the clone up for a bulk drop later. This approach is actually problematic. Without reference counting the clones, the first copy that goes out of scope will cause the mbuf to be returned to the mempool. The additional clone could erroneously free something it in fact no longer owns. To avoid this problem, we will not clone mbufs anymore inside the combinators. The downside is, on errors, mbufs will not be bulk freed.