### PR TITLE
kni and mempool stats

### DIFF
--- a/core/src/dpdk/kni.rs
+++ b/core/src/dpdk/kni.rs
@@ -42,7 +42,7 @@ impl KniRx {
         KniRx { raw }
     }
 
-    /// Creates a new `KniRx`.
+    /// Creates a new `KniRx` with stats.
     #[cfg(feature = "metrics")]
     pub fn new(raw: NonNull<ffi::rte_kni>) -> Self {
         let name = unsafe { ffi::rte_kni_get_name(raw.as_ref()).as_str().to_owned() };
@@ -135,7 +135,7 @@ impl KniTx {
         }
     }
 
-    /// Creates a new `KniTx`.
+    /// Creates a new `KniTx` with stats.
     #[cfg(feature = "metrics")]
     pub fn new(raw: NonNull<ffi::rte_kni>, tx_deque: UnboundedReceiver<Vec<Mbuf>>) -> Self {
         let name = unsafe { ffi::rte_kni_get_name(raw.as_ref()).as_str().to_owned() };

--- a/core/src/dpdk/kni.rs
+++ b/core/src/dpdk/kni.rs
@@ -1,5 +1,7 @@
 use super::{CoreId, Mbuf, PortId};
-use crate::ffi::{self, ToResult};
+use crate::ffi::{self, AsStr, ToResult};
+#[cfg(feature = "metrics")]
+use crate::metrics::{labels, Counter, SINK};
 use crate::net::MacAddr;
 use crate::{debug, error, warn, Result};
 use failure::Fail;
@@ -10,14 +12,49 @@ use std::os::raw;
 use std::ptr::{self, NonNull};
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 
+/// Creates a new KNI counter.
+#[cfg(feature = "metrics")]
+fn new_counter(name: &'static str, kni: &str, dir: &'static str) -> Counter {
+    SINK.scoped("kni").counter_with_labels(
+        name,
+        labels!(
+            "kni" => kni.to_string(),
+            "dir" => dir,
+        ),
+    )
+}
+
 /// The KNI receive handle. Because the underlying interface is single
 /// threaded, we must ensure that only one rx handle is created for each
 /// interface.
 pub struct KniRx {
     raw: NonNull<ffi::rte_kni>,
+    #[cfg(feature = "metrics")]
+    pkt_counter: Counter,
+    #[cfg(feature = "metrics")]
+    byte_counter: Counter,
 }
 
 impl KniRx {
+    /// Creates a new `KniRx`.
+    #[cfg(not(feature = "metrics"))]
+    pub fn new(raw: NonNull<ffi::rte_kni>) -> Self {
+        KniRx { raw }
+    }
+
+    /// Creates a new `KniRx`.
+    #[cfg(feature = "metrics")]
+    pub fn new(raw: NonNull<ffi::rte_kni>) -> Self {
+        let name = unsafe { ffi::rte_kni_get_name(raw.as_ref()).as_str().to_owned() };
+        let pkt_counter = new_counter("packets", &name, "rx");
+        let byte_counter = new_counter("octets", &name, "rx");
+        KniRx {
+            raw,
+            pkt_counter,
+            byte_counter,
+        }
+    }
+
     /// Receives a burst of packets from the kernel, up to a maximum of
     /// 32 packets.
     pub fn receive(&mut self) -> Vec<Mbuf> {
@@ -43,6 +80,14 @@ impl KniRx {
             if let Err(err) = ffi::rte_kni_handle_request(self.raw.as_mut()).to_result() {
                 warn!(message = "failed to handle change link requests.", ?err);
             }
+        }
+
+        #[cfg(feature = "metrics")]
+        {
+            self.pkt_counter.record(mbufs.len() as u64);
+
+            let bytes: usize = mbufs.iter().map(Mbuf::data_len).sum();
+            self.byte_counter.record(bytes as u64);
         }
 
         mbufs
@@ -72,9 +117,40 @@ impl KniTxQueue {
 pub struct KniTx {
     raw: NonNull<ffi::rte_kni>,
     tx_deque: Option<UnboundedReceiver<Vec<Mbuf>>>,
+    #[cfg(feature = "metrics")]
+    pkt_counter: Counter,
+    #[cfg(feature = "metrics")]
+    byte_counter: Counter,
+    #[cfg(feature = "metrics")]
+    drop_counter: Counter,
 }
 
 impl KniTx {
+    /// Creates a new `KniTx`.
+    #[cfg(not(feature = "metrics"))]
+    pub fn new(raw: NonNull<ffi::rte_kni>, tx_deque: UnboundedReceiver<Vec<Mbuf>>) -> Self {
+        KniTx {
+            raw,
+            tx_deque: Some(tx_deque),
+        }
+    }
+
+    /// Creates a new `KniTx`.
+    #[cfg(feature = "metrics")]
+    pub fn new(raw: NonNull<ffi::rte_kni>, tx_deque: UnboundedReceiver<Vec<Mbuf>>) -> Self {
+        let name = unsafe { ffi::rte_kni_get_name(raw.as_ref()).as_str().to_owned() };
+        let pkt_counter = new_counter("packets", &name, "tx");
+        let byte_counter = new_counter("octets", &name, "tx");
+        let drop_counter = new_counter("dropped", &name, "tx");
+        KniTx {
+            raw,
+            tx_deque: Some(tx_deque),
+            pkt_counter,
+            byte_counter,
+            drop_counter,
+        }
+    }
+
     /// Sends the packets to the kernel.
     pub fn transmit(&mut self, mut packets: Vec<Mbuf>) {
         loop {
@@ -89,6 +165,14 @@ impl KniTx {
             };
 
             if sent > 0 {
+                #[cfg(feature = "metrics")]
+                {
+                    self.pkt_counter.record(sent as u64);
+
+                    let bytes: usize = packets[..sent as usize].iter().map(Mbuf::data_len).sum();
+                    self.byte_counter.record(bytes as u64);
+                }
+
                 if to_send - sent > 0 {
                     // still have packets not sent. tx queue is full but still making
                     // progress. we will keep trying until all packets are sent. drains
@@ -106,7 +190,9 @@ impl KniTx {
             } else {
                 // tx queue is full and we can't make progress, start dropping packets
                 // to avoid potentially stuck in an endless loop.
-                warn!("tx full, dropped {} packets.", to_send);
+                #[cfg(feature = "metrics")]
+                self.drop_counter.record(to_send as u64);
+
                 Mbuf::free_bulk(packets);
                 break;
             }
@@ -159,11 +245,8 @@ impl Kni {
         // making 3 clones of the same raw pointer. but we know it is safe
         // to do because rx and tx happen on two independent queues. so while
         // each one is single-threaded, they can function in parallel.
-        let rx = KniRx { raw };
-        let tx = KniTx {
-            raw,
-            tx_deque: Some(recv),
-        };
+        let rx = KniRx::new(raw);
+        let tx = KniTx::new(raw, recv);
         let txq = KniTxQueue { tx_enque: send };
 
         Kni {

--- a/core/src/dpdk/mempool.rs
+++ b/core/src/dpdk/mempool.rs
@@ -7,9 +7,6 @@ use std::os::raw;
 use std::ptr::{self, NonNull};
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-// A global counter used to generate a unique name for new mempools.
-static MEMPOOL_COUNT: AtomicUsize = AtomicUsize::new(0);
-
 /// A memory pool is an allocator of message buffers, or `Mbuf`. For best
 /// performance, each socket should have a dedicated `Mempool`.
 pub struct Mempool {
@@ -34,8 +31,10 @@ impl Mempool {
     ///
     /// If allocation fails, then `DpdkError` is returned.
     pub fn new(capacity: usize, cache_size: usize, socket_id: SocketId) -> Result<Self> {
+        static MEMPOOL_COUNT: AtomicUsize = AtomicUsize::new(0);
         let n = MEMPOOL_COUNT.fetch_add(1, Ordering::Relaxed);
         let name = format!("mempool{}", n).to_cstring();
+
         let raw = unsafe {
             ffi::rte_pktmbuf_pool_create(
                 name.as_ptr(),
@@ -67,6 +66,11 @@ impl Mempool {
     #[inline]
     pub fn name(&self) -> &str {
         self.raw().name[..].as_str()
+    }
+
+    #[cfg(feature = "metrics")]
+    pub fn stats(&self) -> super::MempoolStats {
+        super::MempoolStats::build(self)
     }
 }
 

--- a/core/src/dpdk/port.rs
+++ b/core/src/dpdk/port.rs
@@ -1,5 +1,3 @@
-#[cfg(feature = "metrics")]
-use super::PortStats;
 use super::{CoreId, Kni, KniBuilder, KniTxQueue, Mbuf, SocketId};
 use crate::ffi::{self, AsStr, ToCString, ToResult};
 #[cfg(feature = "metrics")]
@@ -258,8 +256,8 @@ impl Port {
     }
 
     #[cfg(feature = "metrics")]
-    pub fn stats(&self) -> PortStats {
-        PortStats::build(self)
+    pub fn stats(&self) -> super::PortStats {
+        super::PortStats::build(self)
     }
 }
 

--- a/core/src/dpdk/stats.rs
+++ b/core/src/dpdk/stats.rs
@@ -1,7 +1,8 @@
-use super::{CoreId, Port, PortId};
-use crate::ffi::{self, ToResult};
+use super::{CoreId, Mempool, Port, PortId};
+use crate::ffi::{self, AsStr, ToResult};
 use crate::metrics::{labels, Key, Measurement};
 use crate::Result;
+use std::ptr::NonNull;
 
 /// Port stats collector.
 pub struct PortStats {
@@ -117,3 +118,55 @@ impl PortStats {
         Ok(values)
     }
 }
+
+/// Mempool stats collector.
+pub struct MempoolStats {
+    raw: NonNull<ffi::rte_mempool>,
+}
+
+impl MempoolStats {
+    /// Builds a collector from the port.
+    pub fn build(mempool: &Mempool) -> Self {
+        MempoolStats {
+            raw: unsafe {
+                NonNull::new_unchecked(
+                    mempool.raw() as *const ffi::rte_mempool as *mut ffi::rte_mempool
+                )
+            },
+        }
+    }
+
+    fn raw(&self) -> &ffi::rte_mempool {
+        unsafe { self.raw.as_ref() }
+    }
+
+    /// Returns the name of the `Mempool`.
+    fn name(&self) -> &str {
+        self.raw().name[..].as_str()
+    }
+
+    /// Returns a gauge.
+    fn new_gauge(&self, name: &'static str, value: i64) -> (Key, Measurement) {
+        (
+            Key::from_name_and_labels(
+                name,
+                labels!(
+                    "pool" => self.name().to_string(),
+                ),
+            ),
+            Measurement::Gauge(value),
+        )
+    }
+
+    /// Collects the mempool stats.
+    pub fn collect(&self) -> Vec<(Key, Measurement)> {
+        let used = unsafe { ffi::rte_mempool_in_use_count(self.raw()) as i64 };
+        let free = self.raw().size as i64 - used;
+
+        vec![self.new_gauge("used", used), self.new_gauge("free", free)]
+    }
+}
+
+/// Send mempool stats across threads.
+unsafe impl Send for MempoolStats {}
+unsafe impl Sync for MempoolStats {}

--- a/core/src/metrics.rs
+++ b/core/src/metrics.rs
@@ -19,6 +19,17 @@
 //! metrics are available if the number of assigned cores to the port is less
 //! than or equal to `RTE_ETHDEV_QUEUE_STAT_CNTRS`. Otherwise, only the
 //! overall metrics are tracked.
+//!
+//! # KNI metrics
+//!
+//! * `kni.packets`, total number of successfully received or transmitted
+//! packets.
+//! * `kni.octets`, total number of successfully received or transmitted bytes.
+//! * `kni.dropped`, total number of packets dropped because the transmit
+//! queue is full.
+//!
+//! Each metric is labeled with the KNI interface name and a direction, which
+//! can be either RX or TX.
 
 // re-export some metrics types to make feature gated imports easier.
 pub(crate) use metrics_core::{labels, Key};

--- a/core/src/runtime/mempool_map.rs
+++ b/core/src/runtime/mempool_map.rs
@@ -36,6 +36,11 @@ impl MempoolMap {
         let inner = self.inner.iter_mut().map(|(&k, v)| (k, v)).collect();
         MempoolMap2 { inner }
     }
+
+    /// Returns the mempool iterator.
+    pub fn pools(&self) -> impl Iterator<Item = &Mempool> {
+        self.inner.values()
+    }
 }
 
 /// A mutable borrow of `MempoolMap` so we can share the mempools mutably

--- a/core/src/runtime/mod.rs
+++ b/core/src/runtime/mod.rs
@@ -83,7 +83,10 @@ impl Runtime {
         }
 
         #[cfg(feature = "metrics")]
-        crate::metrics::register_port_stats(&ports);
+        {
+            crate::metrics::register_port_stats(&ports);
+            crate::metrics::register_mempool_stats(mempools.pools());
+        }
 
         info!("runtime ready.");
 

--- a/examples/kni/Cargo.toml
+++ b/examples/kni/Cargo.toml
@@ -18,6 +18,8 @@ doctest = false
 
 [dependencies]
 failure = "0.1"
+metrics-core = "0.5"
+metrics-runtime = "0.12"
 nb2 = { path = "../../core" }
 tracing = "0.1"
 tracing-subscriber = "0.1"

--- a/examples/kni/main.rs
+++ b/examples/kni/main.rs
@@ -1,11 +1,21 @@
+use metrics_core::{Builder, Drain, Observe};
+use metrics_runtime::observers::YamlBuilder;
+use nb2::metrics;
 use nb2::settings::load_config;
 use nb2::{batch, Result, Runtime};
+use std::time::Duration;
 use tracing::{debug, Level};
 use tracing_subscriber::fmt;
 
+fn print_stats() {
+    let mut observer = YamlBuilder::new().build();
+    metrics::global().controller().observe(&mut observer);
+    println!("{}", observer.drain());
+}
+
 fn main() -> Result<()> {
     let subscriber = fmt::Subscriber::builder()
-        .with_max_level(Level::DEBUG)
+        .with_max_level(Level::INFO)
         .finish();
     tracing::subscriber::set_global_default(subscriber)?;
 
@@ -17,5 +27,6 @@ fn main() -> Result<()> {
             batch::splice(q.clone(), q.kni().unwrap().clone())
         })?
         .add_kni_rx_pipeline_to_port("kni0", batch::splice)?
+        .add_periodic_task_to_core(0, print_stats, Duration::from_secs(1))?
         .execute()
 }


### PR DESCRIPTION
sample output of KNI stats

```
---
nb2:
  kni:
    "dropped{kni=\"kni0\",dir=\"tx\"}": 0
    "octets{kni=\"kni0\",dir=\"rx\"}": 6460
    "octets{kni=\"kni0\",dir=\"tx\"}": 0
    "packets{kni=\"kni0\",dir=\"rx\"}": 64
    "packets{kni=\"kni0\",dir=\"tx\"}": 0
  port:
    "dropped{port=\"kni0\",dir=\"rx\"}": 0
    "dropped{port=\"kni0\",dir=\"tx\"}": 0
    "errors{port=\"kni0\",dir=\"rx\"}": 0
    "errors{port=\"kni0\",dir=\"tx\"}": 0
    "no_mbuf{port=\"kni0\",dir=\"rx\"}": 0
    "octets{port=\"kni0\",dir=\"rx\",core=\"1\"}": 0
    "octets{port=\"kni0\",dir=\"tx\",core=\"1\"}": 6460
    "packets{port=\"kni0\",dir=\"rx\",core=\"1\"}": 0
    "packets{port=\"kni0\",dir=\"tx\",core=\"1\"}": 64
```

sample output of mempool stats

```
---
nb2:
  mempool:
    "free{pool=\"mempool0\"}": 65151
    "used{pool=\"mempool0\"}": 384
```