### PR TITLE
fix: stats mapping breaks net_ring and net_pcap

### DIFF
--- a/core/src/dpdk/port.rs
+++ b/core/src/dpdk/port.rs
@@ -493,25 +493,6 @@ impl<'a> PortBuilder<'a> {
 
             #[cfg(feature = "metrics")]
             {
-                // have space to set up the stats per core.
-                if ffi::RTE_ETHDEV_QUEUE_STAT_CNTRS >= len as u32 {
-                    unsafe {
-                        ffi::rte_eth_dev_set_rx_queue_stats_mapping(
-                            self.port_id.0,
-                            idx as u16,
-                            idx as u8,
-                        )
-                        .to_result()?;
-
-                        ffi::rte_eth_dev_set_tx_queue_stats_mapping(
-                            self.port_id.0,
-                            idx as u16,
-                            idx as u8,
-                        )
-                        .to_result()?;
-                    }
-                }
-
                 // counter to track dropped TX packets.
                 let counter = SINK.scoped("port").counter_with_labels(
                     "dropped",


### PR DESCRIPTION
Stats mapping breaks virtual dev drivers like net_ring and net_pcap. Turns out the documentation didn't make this very clear. You only need to call these 2 functions to remap the queue to stats mapping. Did some spot checking, and seems like all drivers are keeping per queue stats without needing to call these functions. The queue index maps to stats index, exactly what we need anyway. We can delete these calls.