### PR TITLE
fix cargo test from a subdir

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -39,9 +39,8 @@ tokio-timer = "=0.3.0-alpha.6"
 tracing = "0.1"
 
 [dev-dependencies]
-colored = ">= 1.6"
+criterion = "0.3"
 proptest = { version = "0.9", default-features = false, features = ["default-code-coverage"] }
-tracing-subscriber = "0.1"
 
 [features]
 default = ["metrics"]


### PR DESCRIPTION
turns out we do need to repeat criterion in dev deps too. otherwise if you try to run `cargo test` from the core subdir, you get this nice compilation message.

```
root@ubuntu-bionic:/opt/shitbricks/core# cargo test
   Compiling nb2 v0.1.0 (/opt/shitbricks/core)
error[E0432]: unresolved import `criterion`
 --> core/src/testils/criterion.rs:2:5
  |
2 | use criterion::{black_box, Bencher};
  |     ^^^^^^^^^ help: a similar path exists: `super::criterion`

error: aborting due to previous error

For more information about this error, try `rustc --explain E0432`.
error: could not compile `nb2`.
```

not exactly sure why, but too lazy to find out. so we will add it back in both places. reason it's nice to run tests from the subdir is if I'm making breaking changes. would be nice to make sure core compiles and passes all the tests before fixing all the examples.

also removed the other two lines. they were added when we tried to use `cargo run example`. we don't do that anymore so no longer needed.