### PR TITLE
pin bindgen to revision 0.51.1

### DIFF
--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -17,7 +17,8 @@ name = "nb2_ffi"
 doctest = false
 
 [build-dependencies]
-bindgen = "0.51"
+# must be pinned to 0.51.1 revision exactly
+bindgen = "0.51.1"
 cc = "1.0"
 
 [dependencies]


### PR DESCRIPTION
For some reason we must pin `bindgen` to the exact revision here. If we don't somehow it could end up generating bad bindings that fails to compile. not sure what causes the resolution to behave differently, but pinning it to the exact revision seems to fix the issue.

```
 Compiling config v0.9.3
error[E0204]: the trait `Copy` may not be implemented for this type
     --> /opt/semantics/target/debug/build/nb2-ffi-3c915c134b754cad/out/bindings.rs:18511:26
      |
18511 | #[derive(Debug, Default, Copy, Clone, PartialEq)]
      |                          ^^^^
...
18519 |     pub pkts: __IncompleteArrayField<*mut rte_mbuf>,
      |     ----------------------------------------------- this field does not implement `Copy`

error[E0204]: the trait `Copy` may not be implemented for this type
     --> /opt/semantics/target/debug/build/nb2-ffi-3c915c134b754cad/out/bindings.rs:22525:26
      |
22525 | #[derive(Debug, Default, Copy, Clone, PartialEq)]
      |                          ^^^^
...
22536 |     pub buffer: __IncompleteArrayField<*mut ::std::os::raw::c_void>,
      |     --------------------------------------------------------------- this field does not implement `Copy`

error: aborting due to 2 previous errors

For more information about this error, try `rustc --explain E0204`.
error: could not compile `nb2-ffi`.
```