### PR TITLE
miscellaneous fixes

### DIFF
--- a/core/src/batch/group_by.rs
+++ b/core/src/batch/group_by.rs
@@ -35,7 +35,7 @@ impl<T: Packet> Batch for Bridge<T> {
 }
 
 /// Builder closure for a sub batch from a bridge.
-pub type GroupByBatchBuilder<T> = dyn Fn(Bridge<T>) -> Box<dyn Batch<Item = T>>;
+pub type GroupByBatchBuilder<T> = dyn FnOnce(Bridge<T>) -> Box<dyn Batch<Item = T>>;
 
 /// A batch that splits the underlying batch into multiple sub batches.
 ///

--- a/core/src/net/mod.rs
+++ b/core/src/net/mod.rs
@@ -1,5 +1,5 @@
 mod cidr;
 mod mac;
 
-pub use self::cidr::{CidrParseError, Ipv4Cidr, Ipv6Cidr};
+pub use self::cidr::{Cidr, CidrParseError, Ipv4Cidr, Ipv6Cidr};
 pub use self::mac::{MacAddr, MacParseError};

--- a/core/src/settings.rs
+++ b/core/src/settings.rs
@@ -56,7 +56,7 @@ impl<'de> Deserialize<'de> for Ipv6Cidr {
 }
 
 /// Runtime settings.
-#[derive(Deserialize)]
+#[derive(Clone, Deserialize)]
 pub struct RuntimeSettings {
     /// Application name. This must be unique if you want to run multiple
     /// DPDK applications on the same system.
@@ -195,7 +195,7 @@ impl fmt::Debug for RuntimeSettings {
 }
 
 /// Mempool settings.
-#[derive(Deserialize)]
+#[derive(Clone, Deserialize)]
 pub struct MempoolSettings {
     /// The maximum number of Mbufs the mempool can allocate. The optimum
     /// size (in terms of memory usage) is when n is a power of two minus
@@ -228,7 +228,7 @@ impl fmt::Debug for MempoolSettings {
 }
 
 /// Port settings.
-#[derive(Deserialize)]
+#[derive(Clone, Deserialize)]
 pub struct PortSettings {
     /// The application assigned logical name of the port.
     ///

--- a/core/src/testils/proptest/strategy.rs
+++ b/core/src/testils/proptest/strategy.rs
@@ -136,24 +136,24 @@ impl StrategyMap {
         self.get::<Ipv6Addr>(key)
     }
 
-    fn sr_segments(&self) -> impl Strategy<Value = (Vec<Ipv6Addr>, usize)> {
+    fn sr_segments(&self) -> impl Strategy<Value = (Vec<Ipv6Addr>, u8)> {
         let mut rvg = Rvg::new();
 
         match (
             self.checked_value::<Vec<Ipv6Addr>>(&field::sr_segments),
-            self.checked_value::<usize>(&field::sr_segments_left),
+            self.checked_value::<u8>(&field::sr_segments_left),
         ) {
             (Some(v), None) => {
                 let segments_left = rvg.generate(0..=v.len());
-                (Just(v).boxed(), Just(segments_left))
+                (Just(v).boxed(), Just(segments_left as u8))
             }
-            (None, Some(v)) => (vec(any::<Ipv6Addr>(), 1..=v).boxed(), Just(v)),
+            (None, Some(v)) => (vec(any::<Ipv6Addr>(), 1..=v as usize).boxed(), Just(v)),
             (Some(segments), Some(segments_left)) => (Just(segments).boxed(), Just(segments_left)),
             _ => {
-                let segments_left = rvg.generate(0..=(8 as usize));
+                let segments_left = rvg.generate(0..=8usize);
                 (
                     vec(any::<Ipv6Addr>(), 1..=segments_left + 1).boxed(),
-                    Just(segments_left),
+                    Just(segments_left as u8),
                 )
             }
         }


### PR DESCRIPTION
a collection of small fixes

* the `GroupByBatchBuilder` is only called once, hence it should be `FnOnce`.
* the `Cidr` trait is re-exported at testils top level like other types.
* make config setting structs clonable.
* randomly generated `segments_left` by proptest should be `u8`.