### PR TITLE
generate takes strategy by ref

### DIFF
--- a/core/src/testils/proptest/strategy.rs
+++ b/core/src/testils/proptest/strategy.rs
@@ -144,13 +144,13 @@ impl StrategyMap {
             self.checked_value::<u8>(&field::sr_segments_left),
         ) {
             (Some(v), None) => {
-                let segments_left = rvg.generate(0..=v.len());
+                let segments_left = rvg.generate(&(0..=v.len()));
                 (Just(v).boxed(), Just(segments_left as u8))
             }
             (None, Some(v)) => (vec(any::<Ipv6Addr>(), 1..=v as usize).boxed(), Just(v)),
             (Some(segments), Some(segments_left)) => (Just(segments).boxed(), Just(segments_left)),
             _ => {
-                let segments_left = rvg.generate(0..=8usize);
+                let segments_left = rvg.generate(&(0..=8usize));
                 (
                     vec(any::<Ipv6Addr>(), 1..=segments_left + 1).boxed(),
                     Just(segments_left as u8),

--- a/core/src/testils/rvg.rs
+++ b/core/src/testils/rvg.rs
@@ -33,7 +33,7 @@ impl Rvg {
     /// let mut gen = Rvg::new();
     /// let udp = gen.generate(v4_udp());
     /// ```
-    pub fn generate<S: Strategy>(&mut self, strategy: S) -> S::Value {
+    pub fn generate<S: Strategy>(&mut self, strategy: &S) -> S::Value {
         strategy
             .new_tree(&mut self.runner)
             .expect("No value can be generated")
@@ -69,7 +69,7 @@ mod tests {
     #[nb2::test]
     fn gen_v4_packet() {
         let mut gen = Rvg::new();
-        let packet = gen.generate(v4_udp());
+        let packet = gen.generate(&v4_udp());
         let udp = packet.into_v4_udp();
         assert_eq!(UdpHeader::size_of(), udp.len());
     }


### PR DESCRIPTION
small fix. the rvg api is not consistent between `generate` and `generate_vec`, now they both accept the strategy by ref.