### PR TITLE
make port promiscuous mode configurable

### DIFF
--- a/core/src/dpdk/port.rs
+++ b/core/src/dpdk/port.rs
@@ -238,7 +238,6 @@ impl Port {
     pub fn start(&mut self) -> Result<()> {
         unsafe {
             ffi::rte_eth_dev_start(self.id.0).to_result()?;
-            ffi::rte_eth_promiscuous_enable(self.id.0);
         }
 
         info!("started port {}.", self.name());
@@ -410,7 +409,7 @@ impl<'a> PortBuilder<'a> {
 
     /// Creates the `Port`.
     #[allow(clippy::cognitive_complexity)]
-    pub fn finish(&mut self, with_kni: bool) -> Result<Port> {
+    pub fn finish(&mut self, promiscuous: bool, with_kni: bool) -> Result<Port> {
         let len = self.cores.len() as u16;
         let conf = ffi::rte_eth_conf::default();
 
@@ -506,6 +505,15 @@ impl<'a> PortBuilder<'a> {
 
             queues.insert(core_id, q);
             debug!("initialized port queue for {:?}.", core_id);
+        }
+
+        // sets the port's promiscuous mode.
+        unsafe {
+            if promiscuous {
+                ffi::rte_eth_promiscuous_enable(self.port_id.0);
+            } else {
+                ffi::rte_eth_promiscuous_disable(self.port_id.0);
+            }
         }
 
         info!("initialized port {}.", self.name);

--- a/core/src/runtime/mod.rs
+++ b/core/src/runtime/mod.rs
@@ -79,7 +79,10 @@ impl Runtime {
                 .cores(&conf.cores)?
                 .mempools(&mut mempools)
                 .rx_tx_queue_capacity(conf.rxd, conf.txd)?
-                .finish(conf.kni.unwrap_or_default())?;
+                .finish(
+                    conf.promiscuous.unwrap_or_default(),
+                    conf.kni.unwrap_or_default(),
+                )?;
 
             debug!(?port);
             ports.push(port);

--- a/core/src/settings.rs
+++ b/core/src/settings.rs
@@ -289,7 +289,10 @@ pub struct PortSettings {
     /// The transmit queue capacity. The default is `128`.
     pub txd: usize,
 
-    /// Whether kernel NIC interface is enabled on this port. with KNI, this
+    /// Whether promiscuous mode is enabled for this port.
+    pub promiscuous: Option<bool>,
+
+    /// Whether kernel NIC interface is enabled for this port. with KNI, this
     /// port can exchange packets with the kernel networking stack. The
     /// default is `false`.
     pub kni: Option<bool>,
@@ -304,6 +307,7 @@ impl Default for PortSettings {
             cores: vec![CoreId::new(0)],
             rxd: DEFAULT_PORT_RXD,
             txd: DEFAULT_PORT_TXD,
+            promiscuous: None,
             kni: None,
         }
     }


### PR DESCRIPTION
makes the promiscuous mode configurable. the default is `false`.