### PR TITLE
icmpv6 time exceeded

### DIFF
--- a/core/src/packets/checksum.rs
+++ b/core/src/packets/checksum.rs
@@ -1,4 +1,4 @@
-use crate::packets::ip::{IpAddrMismatchError, ProtocolNumber};
+use crate::packets::ip::{IpPacketError, ProtocolNumber};
 use crate::Result;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::slice;
@@ -179,7 +179,7 @@ pub fn compute_with_ipaddr(
         (IpAddr::V6(old), IpAddr::V6(new)) => {
             Ok(compute_inc(old_checksum, &old.segments(), &new.segments()))
         }
-        _ => Err(IpAddrMismatchError.into()),
+        _ => Err(IpPacketError::IpAddrMismatch.into()),
     }
 }
 

--- a/core/src/packets/icmp/v6/mod.rs
+++ b/core/src/packets/icmp/v6/mod.rs
@@ -1,10 +1,12 @@
 mod echo_reply;
 mod echo_request;
 pub mod ndp;
+mod time_exceeded;
 mod too_big;
 
 pub use self::echo_reply::*;
 pub use self::echo_request::*;
+pub use self::time_exceeded::*;
 pub use self::too_big::*;
 
 use self::ndp::*;

--- a/core/src/packets/icmp/v6/mod.rs
+++ b/core/src/packets/icmp/v6/mod.rs
@@ -5,9 +5,9 @@ mod too_big;
 
 pub use self::echo_reply::*;
 pub use self::echo_request::*;
-pub use self::ndp::*;
 pub use self::too_big::*;
 
+use self::ndp::*;
 use crate::packets::ip::v6::Ipv6Packet;
 use crate::packets::ip::ProtocolNumbers;
 use crate::packets::{checksum, CondRc, Header, Packet, ParseError};
@@ -213,6 +213,7 @@ pub mod Icmpv6Types {
     use super::Icmpv6Type;
 
     pub const PacketTooBig: Icmpv6Type = Icmpv6Type(2);
+    pub const TimeExceeded: Icmpv6Type = Icmpv6Type(3);
     pub const EchoRequest: Icmpv6Type = Icmpv6Type(128);
     pub const EchoReply: Icmpv6Type = Icmpv6Type(129);
 
@@ -231,6 +232,7 @@ impl fmt::Display for Icmpv6Type {
             "{}",
             match *self {
                 Icmpv6Types::PacketTooBig => "Packet Too Big".to_string(),
+                Icmpv6Types::TimeExceeded => "Time Exceeded".to_string(),
                 Icmpv6Types::EchoRequest => "Echo Request".to_string(),
                 Icmpv6Types::EchoReply => "Echo Reply".to_string(),
                 Icmpv6Types::RouterSolicitation => "Router Solicitation".to_string(),

--- a/core/src/packets/icmp/v6/time_exceeded.rs
+++ b/core/src/packets/icmp/v6/time_exceeded.rs
@@ -1,0 +1,70 @@
+use crate::packets::icmp::v6::{Icmpv6, Icmpv6Packet, Icmpv6Payload, Icmpv6Type, Icmpv6Types};
+use crate::packets::ip::v6::{Ipv6Packet, IPV6_MIN_MTU};
+use crate::packets::Packet;
+use std::fmt;
+
+/// Time Exceeded Message defined in [IETF RFC 4443].
+///
+/// ```
+/// 0                   1                   2                   3
+/// 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+/// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+/// |     Type      |     Code      |          Checksum             |
+/// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+/// |                             Unused                            |
+/// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+/// |                    As much of invoking packet                 |
+/// +               as possible without the ICMPv6 packet           +
+/// |               exceeding the minimum IPv6 MTU [IPv6]           |
+/// ```
+///
+/// [IETF RFC 4443]: https://tools.ietf.org/html/rfc4443#section-3.3
+#[derive(Clone, Copy, Debug, Default)]
+#[repr(C, packed)]
+pub struct TimeExceeded {
+    _unused: u32,
+}
+
+impl Icmpv6Payload for TimeExceeded {
+    fn msg_type() -> Icmpv6Type {
+        Icmpv6Types::TimeExceeded
+    }
+}
+
+impl<E: Ipv6Packet> Icmpv6<E, TimeExceeded> {}
+
+impl<E: Ipv6Packet> fmt::Debug for Icmpv6<E, TimeExceeded> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("icmpv6")
+            .field("type", &format!("{}", self.msg_type()))
+            .field("code", &self.code())
+            .field("checksum", &format!("0x{:04x}", self.checksum()))
+            .field("$offset", &self.offset())
+            .field("$len", &self.len())
+            .field("$header_len", &self.header_len())
+            .finish()
+    }
+}
+
+impl<E: Ipv6Packet> Packet for Icmpv6<E, TimeExceeded> {
+    #[inline]
+    fn cascade(&mut self) {
+        // keeps as much of the invoking packet without exceeding the
+        // minimum MTU, and ignores the error if there's nothing to
+        // truncate.
+        let _ = self.envelope_mut().truncate(IPV6_MIN_MTU);
+        self.compute_checksum();
+        self.envelope_mut().cascade();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::SizeOf;
+
+    #[test]
+    fn size_of_time_exceeded() {
+        assert_eq!(4, TimeExceeded::size_of());
+    }
+}

--- a/core/src/packets/icmp/v6/too_big.rs
+++ b/core/src/packets/icmp/v6/too_big.rs
@@ -1,7 +1,6 @@
 use crate::packets::icmp::v6::{Icmpv6, Icmpv6Packet, Icmpv6Payload, Icmpv6Type, Icmpv6Types};
 use crate::packets::ip::v6::Ipv6Packet;
-use crate::packets::{EthernetHeader, Packet};
-use crate::SizeOf;
+use crate::packets::Packet;
 use std::fmt;
 
 /// Packet Too Big Message defined in [IETF RFC 4443].
@@ -48,7 +47,7 @@ impl<E: Ipv6Packet> Icmpv6<E, PacketTooBig> {
     }
 }
 
-impl<E: Ipv6Packet> fmt::Display for Icmpv6<E, PacketTooBig> {
+impl<E: Ipv6Packet> fmt::Debug for Icmpv6<E, PacketTooBig> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("icmpv6")
             .field("type", &format!("{}", self.msg_type()))
@@ -65,11 +64,9 @@ impl<E: Ipv6Packet> fmt::Display for Icmpv6<E, PacketTooBig> {
 impl<E: Ipv6Packet> Packet for Icmpv6<E, PacketTooBig> {
     #[inline]
     fn cascade(&mut self) {
-        // assuming inside an ethernet frame
-        let max_len = self.mtu() as usize + EthernetHeader::size_of();
-        // only err if nothing to trim, ignore the result
-        let _ = self.mbuf_mut().truncate(max_len);
-
+        let mtu = self.mtu() as usize;
+        // ignores the error if there's nothing to truncate.
+        let _ = self.envelope_mut().truncate(mtu);
         self.compute_checksum();
         self.envelope_mut().cascade();
     }
@@ -78,6 +75,7 @@ impl<E: Ipv6Packet> Packet for Icmpv6<E, PacketTooBig> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::SizeOf;
 
     #[test]
     fn size_of_packet_too_big() {

--- a/core/src/packets/ip/mod.rs
+++ b/core/src/packets/ip/mod.rs
@@ -97,6 +97,9 @@ pub trait IpPacket: Packet {
 
     /// Returns the pseudo-header for layer 4 checksum computation.
     fn pseudo_header(&self, packet_len: u16, protocol: ProtocolNumber) -> PseudoHeader;
+
+    /// Truncates the IP packet to MTU. The data exceeds MTU is lost.
+    fn truncate(&mut self, mtu: usize) -> Result<()>;
 }
 
 /// 5-tuple IP connection identifier.
@@ -225,10 +228,17 @@ impl fmt::Debug for Flow {
     }
 }
 
-/// Error indicating mixing IPv4 and IPv6 addresses in a flow.
+/// IpPacket errors.
 #[derive(Debug, Fail)]
-#[fail(display = "Cannot mix IPv4 and IPv6 addresses")]
-pub struct IpAddrMismatchError;
+pub enum IpPacketError {
+    /// Error indicating mixing IPv4 and IPv6 addresses in a flow.
+    #[fail(display = "Cannot mix IPv4 and IPv6 addresses")]
+    IpAddrMismatch,
+
+    /// Error indicating the MTU is less than the minimum MTU size.
+    #[fail(display = "{} is less than the minimum MTU of {}.", _0, _1)]
+    MtuTooSmall(usize, usize),
+}
 
 #[cfg(test)]
 mod tests {

--- a/core/src/packets/ip/mod.rs
+++ b/core/src/packets/ip/mod.rs
@@ -8,6 +8,11 @@ use failure::Fail;
 use std::fmt;
 use std::net::{IpAddr, Ipv4Addr};
 
+/// [IANA] recommended default TTL for IP.
+///
+/// [IANA]: https://www.iana.org/assignments/ip-parameters/ip-parameters.xml#ip-parameters-2
+pub const DEFAULT_IP_TTL: u8 = 64;
+
 /// [IANA] assigned internet protocol number.
 ///
 /// [IANA]: https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml

--- a/core/src/packets/ip/v4.rs
+++ b/core/src/packets/ip/v4.rs
@@ -1,10 +1,19 @@
 use crate::packets::checksum::PseudoHeader;
-use crate::packets::ip::{IpAddrMismatchError, IpPacket, ProtocolNumber};
+use crate::packets::ip::{IpPacket, IpPacketError, ProtocolNumber};
 use crate::packets::{CondRc, EtherTypes, Ethernet, Header, Packet, ParseError};
 use crate::{ensure, Result, SizeOf};
 use std::fmt;
 use std::net::{IpAddr, Ipv4Addr};
 use std::ptr::NonNull;
+
+/// The minimum IPv4 MTU defined in [IETF RFC 791].
+///
+/// Every internet module must be able to forward a datagram of 68 octets
+/// without further fragmentation.  This is because an internet header may
+/// be up to 60 octets, and the minimum fragment is 8 octets.
+///
+/// [IETF RFC 791]: https://tools.ietf.org/html/rfc791
+pub const IPV4_MIN_MTU: usize = 68;
 
 // Masks.
 const DSCP: u8 = 0b1111_1100;
@@ -451,7 +460,7 @@ impl IpPacket for Ipv4 {
                 self.set_src(addr);
                 Ok(())
             }
-            _ => Err(IpAddrMismatchError.into()),
+            _ => Err(IpPacketError::IpAddrMismatch.into()),
         }
     }
 
@@ -467,7 +476,7 @@ impl IpPacket for Ipv4 {
                 self.set_dst(addr);
                 Ok(())
             }
-            _ => Err(IpAddrMismatchError.into()),
+            _ => Err(IpPacketError::IpAddrMismatch.into()),
         }
     }
 
@@ -479,6 +488,18 @@ impl IpPacket for Ipv4 {
             packet_len,
             protocol,
         }
+    }
+
+    #[inline]
+    fn truncate(&mut self, mtu: usize) -> Result<()> {
+        ensure!(
+            mtu >= IPV4_MIN_MTU,
+            IpPacketError::MtuTooSmall(mtu, IPV4_MIN_MTU)
+        );
+
+        // accounts for the ethernet frame length.
+        let to_len = mtu + self.offset();
+        self.mbuf_mut().truncate(to_len)
     }
 }
 
@@ -601,5 +622,22 @@ mod tests {
 
         // make sure ether type is fixed
         assert_eq!(EtherTypes::Ipv4, ipv4.envelope().ether_type());
+    }
+
+    #[nb2::test]
+    fn truncate_ipv4_packet() {
+        // prime the buffer with 2000 bytes of data
+        let mut packet = Mbuf::new().unwrap();
+        let _ = packet.extend(0, 2000);
+
+        let ethernet = packet.push::<Ethernet>().unwrap();
+        let mut ipv4 = ethernet.push::<Ipv4>().unwrap();
+
+        // can't truncate to less than minimum MTU.
+        assert!(ipv4.truncate(60).is_err());
+
+        assert!(ipv4.len() > 1000);
+        let _ = ipv4.truncate(1000);
+        assert_eq!(1000, ipv4.len());
     }
 }

--- a/core/src/packets/ip/v4.rs
+++ b/core/src/packets/ip/v4.rs
@@ -1,5 +1,5 @@
 use crate::packets::checksum::PseudoHeader;
-use crate::packets::ip::{IpPacket, IpPacketError, ProtocolNumber};
+use crate::packets::ip::{IpPacket, IpPacketError, ProtocolNumber, DEFAULT_IP_TTL};
 use crate::packets::{CondRc, EtherTypes, Ethernet, Header, Packet, ParseError};
 use crate::{ensure, Result, SizeOf};
 use std::fmt;
@@ -530,7 +530,7 @@ impl Default for Ipv4Header {
             total_length: 0,
             identification: 0,
             flags_to_frag_offset: 0,
-            ttl: 0,
+            ttl: DEFAULT_IP_TTL,
             protocol: 0,
             checksum: 0,
             src: Ipv4Addr::UNSPECIFIED,

--- a/core/src/packets/ip/v6/fragment.rs
+++ b/core/src/packets/ip/v6/fragment.rs
@@ -235,6 +235,11 @@ impl<E: Ipv6Packet> IpPacket for Fragment<E> {
     fn pseudo_header(&self, packet_len: u16, protocol: ProtocolNumber) -> PseudoHeader {
         self.envelope().pseudo_header(packet_len, protocol)
     }
+
+    #[inline]
+    fn truncate(&mut self, mtu: usize) -> Result<()> {
+        self.envelope_mut().truncate(mtu)
+    }
 }
 
 impl<E: Ipv6Packet> Ipv6Packet for Fragment<E> {

--- a/core/src/packets/ip/v6/mod.rs
+++ b/core/src/packets/ip/v6/mod.rs
@@ -5,7 +5,7 @@ pub use self::fragment::*;
 pub use self::srh::*;
 
 use crate::packets::checksum::PseudoHeader;
-use crate::packets::ip::{IpPacket, IpPacketError, ProtocolNumber};
+use crate::packets::ip::{IpPacket, IpPacketError, ProtocolNumber, DEFAULT_IP_TTL};
 use crate::packets::{CondRc, EtherTypes, Ethernet, Header, Packet, ParseError};
 use crate::{ensure, Result, SizeOf};
 use std::fmt;
@@ -74,8 +74,6 @@ const FLOW: u32 = 0xfffff;
 /// [IETF RFC 8200]: https://tools.ietf.org/html/rfc8200#section-3
 /// [IETF RFC 2474]: https://tools.ietf.org/html/rfc2474
 /// [IETF RFC 3168]: https://tools.ietf.org/html/rfc3168
-
-/// IPv6 packet.
 #[derive(Clone)]
 pub struct Ipv6 {
     envelope: CondRc<Ethernet>,
@@ -395,7 +393,7 @@ impl Default for Ipv6Header {
             version_to_flow_label: u32::to_be(6 << 28),
             payload_length: 0,
             next_header: 0,
-            hop_limit: 0,
+            hop_limit: DEFAULT_IP_TTL,
             src: Ipv6Addr::UNSPECIFIED,
             dst: Ipv6Addr::UNSPECIFIED,
         }

--- a/core/src/packets/ip/v6/mod.rs
+++ b/core/src/packets/ip/v6/mod.rs
@@ -5,7 +5,7 @@ pub use self::fragment::*;
 pub use self::srh::*;
 
 use crate::packets::checksum::PseudoHeader;
-use crate::packets::ip::{IpAddrMismatchError, IpPacket, ProtocolNumber};
+use crate::packets::ip::{IpPacket, IpPacketError, ProtocolNumber};
 use crate::packets::{CondRc, EtherTypes, Ethernet, Header, Packet, ParseError};
 use crate::{ensure, Result, SizeOf};
 use std::fmt;
@@ -313,7 +313,7 @@ impl IpPacket for Ipv6 {
                 self.set_src(addr);
                 Ok(())
             }
-            _ => Err(IpAddrMismatchError.into()),
+            _ => Err(IpPacketError::IpAddrMismatch.into()),
         }
     }
 
@@ -329,7 +329,7 @@ impl IpPacket for Ipv6 {
                 self.set_dst(addr);
                 Ok(())
             }
-            _ => Err(IpAddrMismatchError.into()),
+            _ => Err(IpPacketError::IpAddrMismatch.into()),
         }
     }
 
@@ -341,6 +341,18 @@ impl IpPacket for Ipv6 {
             packet_len,
             protocol,
         }
+    }
+
+    #[inline]
+    fn truncate(&mut self, mtu: usize) -> Result<()> {
+        ensure!(
+            mtu >= IPV6_MIN_MTU,
+            IpPacketError::MtuTooSmall(mtu, IPV6_MIN_MTU)
+        );
+
+        // accounts for the ethernet frame length.
+        let to_len = mtu + self.offset();
+        self.mbuf_mut().truncate(to_len)
     }
 }
 
@@ -493,5 +505,22 @@ mod tests {
 
         // make sure ether type is fixed
         assert_eq!(EtherTypes::Ipv6, ipv6.envelope().ether_type());
+    }
+
+    #[nb2::test]
+    fn truncate_ipv6_packet() {
+        // prime the buffer with 1800 bytes of data
+        let mut packet = Mbuf::new().unwrap();
+        let _ = packet.extend(0, 1800);
+
+        let ethernet = packet.push::<Ethernet>().unwrap();
+        let mut ipv6 = ethernet.push::<Ipv6>().unwrap();
+
+        // can't truncate to less than minimum MTU.
+        assert!(ipv6.truncate(1200).is_err());
+
+        assert!(ipv6.len() > 1500);
+        let _ = ipv6.truncate(1500);
+        assert_eq!(1500, ipv6.len());
     }
 }

--- a/core/src/packets/ip/v6/srh.rs
+++ b/core/src/packets/ip/v6/srh.rs
@@ -401,6 +401,11 @@ impl<E: Ipv6Packet> IpPacket for SegmentRouting<E> {
             protocol,
         }
     }
+
+    #[inline]
+    fn truncate(&mut self, mtu: usize) -> Result<()> {
+        self.envelope_mut().truncate(mtu)
+    }
 }
 
 impl<E: Ipv6Packet> Ipv6Packet for SegmentRouting<E> {


### PR DESCRIPTION
adds support for ICMPv6 Time Exceeded message. also fixing how truncate was implemented to account for dynamically sized ethernet frames. the old implementation doesn't work if there are vlan tags on the ethernet frames.