### PR TITLE
group-by with or (via `,`, like in erlang)

### DIFF
--- a/core/src/batch/group_by.rs
+++ b/core/src/batch/group_by.rs
@@ -141,13 +141,19 @@ macro_rules! __compose {
 /// Composes the batch builders for the `group_by` combinator
 #[macro_export]
 macro_rules! compose {
-    ($map:ident { $($key:expr => |$arg:tt| $body:block)* }) => {{
+    ($map:ident { $($key:expr => |$arg:tt| $body:block),+ $(,)? }) => {{
         $crate::__compose!($map, $($key => |$arg| $body),*);
         $map.insert(None, Box::new(|group| Box::new(group)));
     }};
-    ($map:ident { $($key:expr => |$arg:tt| $body:block)* _ => |$_arg:tt| $_body:block }) => {{
+    ($map:ident { $($key:expr => |$arg:tt| $body:block),+$(,)? _ => |$_arg:tt| $_body:block }$(,)?) => {{
         $crate::__compose!($map, $($key => |$arg| $body),*);
         $map.insert(None, Box::new(|$_arg| Box::new($_body)));
+    }};
+    ($map:ident { $($key:expr),+ => |$arg:tt| $body:block }) => {{
+        $crate::compose!($map { $($key => |$arg| $body),+ });
+    }};
+    ($map:ident { $($key:expr),+ => |$arg:tt| $body:block, _ => |$_arg:tt| $_body:block }$(,)?) => {{
+        $crate::compose!($map { $($key => |$arg| $body),+, _ => |$_arg| $_body });
     }};
     ($map:ident { _ => |$_arg:tt| $_body:block }) => {{
         $map.insert(None, Box::new(|$_arg| Box::new($_body)));

--- a/examples/nat64/main.rs
+++ b/examples/nat64/main.rs
@@ -140,10 +140,10 @@ fn install(qs: HashMap<String, PortQueue>) -> impl Pipeline {
                 compose!( groups {
                     EtherTypes::Ipv4 => |group| {
                         group.filter_map(nat_4to6)
-                    }
+                    },
                     EtherTypes::Ipv6 => |group| {
                         group.filter_map(nat_6to4)
-                    }
+                    },
                     _ => |group| {
                         group.filter(|_| false)
                     }

--- a/examples/pktdump/main.rs
+++ b/examples/pktdump/main.rs
@@ -60,7 +60,7 @@ fn install(q: PortQueue) -> impl Pipeline {
                 compose!( groups {
                     EtherTypes::Ipv4 => |group| {
                         group.for_each(dump_v4)
-                    }
+                    },
                     EtherTypes::Ipv6 => |group| {
                         group.for_each(dump_v6)
                     }


### PR DESCRIPTION
- reasoning: `|` is not allowed in macro_rules, but the comma still makes
  sense
- also, more like patterns normally, we use commas between match blocks (I think we should go this route no matter what you think on the `,` or use @drunkirishcoder)