### PR TITLE
group-by with or (via `,`, like in erlang)

### DIFF
--- a/core/src/batch/group_by.rs
+++ b/core/src/batch/group_by.rs
@@ -141,13 +141,19 @@ macro_rules! __compose {
 /// Composes the batch builders for the `group_by` combinator
 #[macro_export]
 macro_rules! compose {
-    ($map:ident { $($key:expr => |$arg:tt| $body:block)* }) => {{
+    ($map:ident { $($key:expr => |$arg:tt| $body:block)+ }) => {{
         $crate::__compose!($map, $($key => |$arg| $body),*);
         $map.insert(None, Box::new(|group| Box::new(group)));
     }};
-    ($map:ident { $($key:expr => |$arg:tt| $body:block)* _ => |$_arg:tt| $_body:block }) => {{
+    ($map:ident { $($key:expr => |$arg:tt| $body:block)+ _ => |$_arg:tt| $_body:block }) => {{
         $crate::__compose!($map, $($key => |$arg| $body),*);
         $map.insert(None, Box::new(|$_arg| Box::new($_body)));
+    }};
+    ($map:ident { $($key:expr),+ => |$arg:tt| $body:block }) => {{
+        $crate::compose!($map { $($key => |$arg| $body)+ });
+    }};
+    ($map:ident { $($key:expr),+ => |$arg:tt| $body:block _ => |$_arg:tt| $_body:block }) => {{
+        $crate::compose!($map { $($key => |$arg| $body)+ _ => |$_arg| $_body });
     }};
     ($map:ident { _ => |$_arg:tt| $_body:block }) => {{
         $map.insert(None, Box::new(|$_arg| Box::new($_body)));

--- a/core/src/batch/mod.rs
+++ b/core/src/batch/mod.rs
@@ -478,6 +478,80 @@ mod tests {
     }
 
     #[nb2::test]
+    fn group_by_or() {
+        let mut batch = new_batch(&[&TCP_PACKET, &UDP_PACKET, &ICMPV4_PACKET])
+            .map(|p| p.parse::<Ethernet>()?.parse::<Ipv4>())
+            .group_by(
+                |p| p.protocol(),
+                |groups| {
+                    compose!( groups {
+                        ProtocolNumbers::Tcp, ProtocolNumbers::Udp => |group| {
+                            group.map(|mut p| {
+                                p.set_ttl(1);
+                                Ok(p)
+                            })
+                        }
+                        _ => |group| {
+                            group.filter(|_| {
+                                false
+                            })
+                        }
+                    })
+                },
+            );
+
+        // first one is the tcp arm
+        let disp = batch.next().unwrap();
+        assert!(disp.is_act());
+        if let Disposition::Act(pkt) = disp {
+            assert_eq!(1, pkt.ttl());
+        }
+
+        // next one is the udp arm
+        let disp = batch.next().unwrap();
+        assert!(disp.is_act());
+        if let Disposition::Act(pkt) = disp {
+            assert_eq!(1, pkt.ttl());
+        }
+
+        // last one is the catch all arm
+        assert!(batch.next().unwrap().is_drop());
+    }
+
+    #[nb2::test]
+    fn group_by_or_no_catchall() {
+        let mut batch = new_batch(&[&TCP_PACKET, &UDP_PACKET])
+            .map(|p| p.parse::<Ethernet>()?.parse::<Ipv4>())
+            .group_by(
+                |p| p.protocol(),
+                |groups| {
+                    compose!( groups {
+                        ProtocolNumbers::Tcp, ProtocolNumbers::Udp => |group| {
+                            group.map(|mut p| {
+                                p.set_ttl(1);
+                                Ok(p)
+                            })
+                        }
+                    })
+                },
+            );
+
+        // first one is the tcp arm
+        let disp = batch.next().unwrap();
+        assert!(disp.is_act());
+        if let Disposition::Act(pkt) = disp {
+            assert_eq!(1, pkt.ttl());
+        }
+
+        // next one is the udp arm
+        let disp = batch.next().unwrap();
+        assert!(disp.is_act());
+        if let Disposition::Act(pkt) = disp {
+            assert_eq!(1, pkt.ttl());
+        }
+    }
+
+    #[nb2::test]
     fn replace_batch() {
         let mut batch = new_batch(&[&UDP_PACKET]).replace(|_| Mbuf::from_bytes(&TCP_PACKET));
 


### PR DESCRIPTION
- reasoning: `|` is not allowed in macro_rules, but the comma still makes
  sense